### PR TITLE
remove routing and make button go to mainpage

### DIFF
--- a/sdm-iso-front/src/App.js
+++ b/sdm-iso-front/src/App.js
@@ -1,18 +1,31 @@
-import React from 'react';
-import { BrowserRouter, Route, Routes } from 'react-router-dom'
+import { React, useEffect, useState } from 'react';
+import { BrowserRouter, Route, Routes, Navigate } from 'react-router-dom'
 import MainPage from './components/MainPage/MainPage'
 import LoginPage from './components/LoginPage/LoginPage'
 import './index.css';
 
 function App() {
-    return (
-      <BrowserRouter>
-        <Routes>
-          <Route path="/" element={<MainPage/>}/>
-          <Route path="/login" element={<LoginPage/>}/>
-        </Routes>      
-      </BrowserRouter>
-    )
-  }
-  
-  export default App
+  const [isAuthenticated, setIsAuthenticated] = useState(false);
+  const [rootPage, setRootPage] = useState(undefined);
+
+  useEffect(() => {
+    const authenticate = () => { setIsAuthenticated(!isAuthenticated) };
+
+    if (isAuthenticated) {
+      setRootPage(<MainPage />)
+    } else {
+      setRootPage(<LoginPage authenticateFn={authenticate} />)
+    }
+  }, [isAuthenticated])
+
+  return (
+    <BrowserRouter>
+      <Routes>
+        <Route path="/" element={rootPage} />
+        <Route path="*" element={<Navigate to="/" />} />
+      </Routes>
+    </BrowserRouter>
+  )
+}
+
+export default App

--- a/sdm-iso-front/src/components/AuthBox/AuthBox.jsx
+++ b/sdm-iso-front/src/components/AuthBox/AuthBox.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-export function AuthBox() {
+export function AuthBox(props) {
   return (
     <div class="min-w-screen min-h-0 h-full flex justify-center items-center">
       <div class="relative bg-iso-offwhite w-2/5 h-2/3 shadow">
@@ -30,7 +30,7 @@ export function AuthBox() {
             </div>
 
               <div className = "inline-flex mt-5 pl-10 items-right">
-                <button className="bg-iso-light-slate hover:bg-iso-link-blue text-white font-semibold py-2 px-4 rounded cursor-pointer float-right">Sign In</button>
+                <button className="bg-iso-light-slate hover:bg-iso-link-blue text-white font-semibold py-2 px-4 rounded cursor-pointer float-right" onClick={props.authenticateFn}>Sign In</button>
               </div>
           </div> 
 

--- a/sdm-iso-front/src/components/LoginPage/LoginPage.jsx
+++ b/sdm-iso-front/src/components/LoginPage/LoginPage.jsx
@@ -3,7 +3,7 @@ import Header from '../Header/Header';
 import AuthBox from '../AuthBox/AuthBox';
 import { PageTitle } from '../PageTitle/PageTitle';
 
-export default function LoginPage () {
+export default function LoginPage (props) {
   return (
     <div className='flex flex-col h-screen'>
       <Header />
@@ -13,7 +13,7 @@ export default function LoginPage () {
           <div className="w-2/3">
             <h1 className="text-4xl mt-10 mb-3 pl-4 pb-1 w-min-min text-center text-iso-slate align-baseline font-light">Sign in</h1>
           </div>
-          <AuthBox />
+          <AuthBox authenticateFn={props.authenticateFn} />
         </div>
       </main>
     </div>


### PR DESCRIPTION
I might be making too many changes here but I don't know.

Now there is no routing like going to /login or /. By default, if not authenticated, any page is login, otherwise, main page. Pressing login button now will let you in. You can change the state to get you in regardless otherwise.

I am not sure about the useEffect whether it is invoked when webpage is loaded. Because if it does not, the page will be nothing showing up. I read somewhere that development build is different from rollout build so maybe it happens, maybe it won't.