### PR TITLE
added period filters

### DIFF
--- a/sdm-iso-back/src/main/java/com/example/sdmisoback/controller/FiltersController.java
+++ b/sdm-iso-back/src/main/java/com/example/sdmisoback/controller/FiltersController.java
@@ -158,16 +158,16 @@ public class FiltersController {
         @Parameter(description = "Must be exact")
         Integer auctionId,
 
-        @RequestParam(name = "resourceTypes", required = false) 
-        @Parameter(description = "Must be exact, searches for any match for {resourceTypes}")
+        @RequestParam(name = "auctionTypes", required = false) 
+        @Parameter(description = "Must be exact, searches for any match for {auctionTypes}")
         List<String> auctionTypes,
 
         @RequestParam(name = "aucBeginDate", required = false) 
-        @Parameter(description = "Must be exact Type java.time LocalDateTime, format 'yyyy-MM-ddTHH:mm:ss' ex '2018-04-01T04:00:00'")
+        @Parameter(description = "Must be exact, searches for dates greater than equal to precise date. Down to the millisecond.")
         LocalDateTime aucBeginDate,
 
         @RequestParam(name = "aucEndDate", required = false) 
-        @Parameter(description = "Must be exact Type java.time LocalDateTime, format 'yyyy-MM-ddTHH:mm:ss' ex '2018-04-01T04:00:00'")
+        @Parameter(description = "Must be exact, searches for dates less than equal to precise date. Down to the millisecond.")
         LocalDateTime aucEndDate,
 
         // commitment period filters
@@ -184,11 +184,11 @@ public class FiltersController {
         String commitPeriodDesc,
 
         @RequestParam(name = "commitPeriodBeginDate", required = false) 
-        @Parameter(description = "Must be exact(?) Type java.time LocalDateTime, format 'yyyy-MM-ddTHH:mm:ss' ex '2018-04-01T04:00:00'")
+        @Parameter(description = "Must be exact, searches for dates greater than equal to precise date. Down to the millisecond.")
         LocalDateTime commitPeriodBeginDate,
 
         @RequestParam(name = "commitPeriodEndDate", required = false) 
-        @Parameter(description = "Must be exact(?) Type java.time LocalDateTime, format 'yyyy-MM-ddTHH:mm:ss' ex '2018-04-01T04:00:00'")
+        @Parameter(description = "Must be exact, searches for dates less than equal to precise date. Down to the millisecond.")
         LocalDateTime commitPeriodEndDate,
     
         @RequestParam(name = "aucPeriodId", required = false) 
@@ -204,11 +204,11 @@ public class FiltersController {
         String aucPeriodDesc,
 
         @RequestParam(name = "aucPeriodBeginDate", required = false) 
-        @Parameter(description = "Must be exact(?) Type java.time LocalDateTime, format 'yyyy-MM-ddTHH:mm:ss' ex '2018-04-01T04:00:00'")
+        @Parameter(description = "Must be exact, searches for dates greater than equal to precise date. Down to the millisecond.")
         LocalDateTime aucPeriodBeginDate,
 
         @RequestParam(name = "aucPeriodEndDate", required = false) 
-        @Parameter(description = "Must be exact(?) Type java.time LocalDateTime, format 'yyyy-MM-ddTHH:mm:ss' ex '2018-04-01T04:00:00'")
+        @Parameter(description = "Must be exact, searches for dates less than equal to precise date. Down to the millisecond.")
         LocalDateTime aucPeriodEndDate
 
         ) { //end parameters

--- a/sdm-iso-back/src/main/java/com/example/sdmisoback/controller/FiltersController.java
+++ b/sdm-iso-back/src/main/java/com/example/sdmisoback/controller/FiltersController.java
@@ -102,6 +102,10 @@ public class FiltersController {
         @Parameter(description = "Must be exact")
         Integer propPeriodId,
 
+        @RequestParam(name = "propPeriodTypes", required = false) 
+        @Parameter(description = "Must be exact, can have multiple")
+        List<String> propPeriodTypes,
+
         @RequestParam(name = "propPeriodDesc", required = false) 
         @Parameter(description = "Searches for prefix: '200' can return file with proposal description '2001-02'")
         String propPeriodDesc,
@@ -150,6 +154,23 @@ public class FiltersController {
         List<String> resourceTypes,
 
         // auction filters
+        @RequestParam(name = "auctionId", required = false) 
+        @Parameter(description = "Must be exact")
+        Integer auctionId,
+
+        @RequestParam(name = "resourceTypes", required = false) 
+        @Parameter(description = "Must be exact, searches for any match for {resourceTypes}")
+        List<String> auctionTypes,
+
+        @RequestParam(name = "aucBeginDate", required = false) 
+        @Parameter(description = "Must be exact Type java.time LocalDateTime, format 'yyyy-MM-ddTHH:mm:ss' ex '2018-04-01T04:00:00'")
+        LocalDateTime aucBeginDate,
+
+        @RequestParam(name = "aucEndDate", required = false) 
+        @Parameter(description = "Must be exact Type java.time LocalDateTime, format 'yyyy-MM-ddTHH:mm:ss' ex '2018-04-01T04:00:00'")
+        LocalDateTime aucEndDate,
+
+        // commitment period filters
         @RequestParam(name = "commitPeriodId", required = false) 
         @Parameter(description = "Must be exact")
         Integer commitPeriodId,
@@ -225,10 +246,11 @@ public class FiltersController {
             pr, sortBy, sortAsc,
             fileId, fileName, fileDescription, createdSince, fileTypes,
             attachTypes,
-            proposalId, proposalLabel, propPeriodId, propPeriodDesc, propPeriodBeginDate, propPeriodEndDate,
+            proposalId, proposalLabel, propPeriodId, propPeriodTypes, propPeriodDesc, propPeriodBeginDate, propPeriodEndDate,
             projectId, projectName, projectTypes,
             customerId, customerName,
             resourceId, resourceName, resourceTypes,
+            auctionId, auctionTypes, aucBeginDate, aucEndDate,
             commitPeriodId, commitPeriodTypes, commitPeriodDesc, commitPeriodBeginDate, commitPeriodEndDate,
             aucPeriodId, aucPeriodTypes, aucPeriodDesc, aucPeriodBeginDate, aucPeriodEndDate
         );

--- a/sdm-iso-back/src/main/java/com/example/sdmisoback/controller/FiltersController.java
+++ b/sdm-iso-back/src/main/java/com/example/sdmisoback/controller/FiltersController.java
@@ -1,5 +1,6 @@
 package com.example.sdmisoback.controller;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.List;
@@ -111,12 +112,12 @@ public class FiltersController {
         String propPeriodDesc,
 
         @RequestParam(name = "propPeriodBeginDate", required = false) 
-        @Parameter(description = "Must be exact(?) Type java.time LocalDateTime, format 'yyyy-MM-ddTHH:mm:ss' ex '2018-04-01T04:00:00'")
-        LocalDateTime propPeriodBeginDate,
+        @Parameter(description = "Searches for begin date after {propPeriodBeginDate} format 'yyyy-MM-dd' ex '2018-04-01'")
+        LocalDate propPeriodBeginDate,
 
         @RequestParam(name = "propPeriodEndDate", required = false) 
-        @Parameter(description = "Must be exact(?) Type java.time LocalDateTime, format 'yyyy-MM-ddTHH:mm:ss' ex '2018-04-01T04:00:00'")
-        LocalDateTime propPeriodEndDate,
+        @Parameter(description = "Searches for end date before {propPeriodEndDate} format 'yyyy-MM-dd' ex '2018-04-01'")
+        LocalDate propPeriodEndDate,
 
         // project filters
         @RequestParam(name = "projectId", required = false) 
@@ -163,12 +164,12 @@ public class FiltersController {
         List<String> auctionTypes,
 
         @RequestParam(name = "aucBeginDate", required = false) 
-        @Parameter(description = "Must be exact, searches for dates greater than equal to precise date. Down to the millisecond.")
-        LocalDateTime aucBeginDate,
+        @Parameter(description = "Searches for begin date before {aucBeginDate} format 'yyyy-MM-dd' ex '2018-04-01'")
+        LocalDate aucBeginDate,
 
         @RequestParam(name = "aucEndDate", required = false) 
-        @Parameter(description = "Must be exact, searches for dates less than equal to precise date. Down to the millisecond.")
-        LocalDateTime aucEndDate,
+        @Parameter(description = "Searches for end date before {aucEndDate} format 'yyyy-MM-dd' ex '2018-04-01'")
+        LocalDate aucEndDate,
 
         // commitment period filters
         @RequestParam(name = "commitPeriodId", required = false) 
@@ -184,12 +185,12 @@ public class FiltersController {
         String commitPeriodDesc,
 
         @RequestParam(name = "commitPeriodBeginDate", required = false) 
-        @Parameter(description = "Must be exact, searches for dates greater than equal to precise date. Down to the millisecond.")
-        LocalDateTime commitPeriodBeginDate,
+        @Parameter(description = "Searches for begin date before {commitPeriodBeginDate} format 'yyyy-MM-dd' ex '2018-04-01'")
+        LocalDate commitPeriodBeginDate,
 
         @RequestParam(name = "commitPeriodEndDate", required = false) 
-        @Parameter(description = "Must be exact, searches for dates less than equal to precise date. Down to the millisecond.")
-        LocalDateTime commitPeriodEndDate,
+        @Parameter(description = "Searches for end date before {commitPeriodEndDate} format 'yyyy-MM-dd' ex '2018-04-01'")
+        LocalDate commitPeriodEndDate,
     
         @RequestParam(name = "aucPeriodId", required = false) 
         @Parameter(description = "Must be exact")
@@ -204,12 +205,12 @@ public class FiltersController {
         String aucPeriodDesc,
 
         @RequestParam(name = "aucPeriodBeginDate", required = false) 
-        @Parameter(description = "Must be exact, searches for dates greater than equal to precise date. Down to the millisecond.")
-        LocalDateTime aucPeriodBeginDate,
+        @Parameter(description = "Searches for begin date before {aucPeriodBeginDate} format 'yyyy-MM-dd' ex '2018-04-01'")
+        LocalDate aucPeriodBeginDate,
 
         @RequestParam(name = "aucPeriodEndDate", required = false) 
-        @Parameter(description = "Must be exact, searches for dates less than equal to precise date. Down to the millisecond.")
-        LocalDateTime aucPeriodEndDate
+        @Parameter(description = "Searches for end date before {aucPeriodEndDate} format 'yyyy-MM-dd' ex '2018-04-01'")
+        LocalDate aucPeriodEndDate
 
         ) { //end parameters
 

--- a/sdm-iso-back/src/main/java/com/example/sdmisoback/controller/FiltersController.java
+++ b/sdm-iso-back/src/main/java/com/example/sdmisoback/controller/FiltersController.java
@@ -98,6 +98,22 @@ public class FiltersController {
         @Parameter(description = "Searches for proposal label containing input: '17' can return file with proposal label '2022-05-17-FCA'")
         String proposalLabel,
 
+        @RequestParam(name = "propPeriodId", required = false) 
+        @Parameter(description = "Must be exact")
+        Integer propPeriodId,
+
+        @RequestParam(name = "propPeriodDesc", required = false) 
+        @Parameter(description = "Searches for prefix: '200' can return file with proposal description '2001-02'")
+        String propPeriodDesc,
+
+        @RequestParam(name = "propPeriodBeginDate", required = false) 
+        @Parameter(description = "Must be exact(?) Type java.time LocalDateTime, format 'yyyy-MM-ddTHH:mm:ss' ex '2018-04-01T04:00:00'")
+        LocalDateTime propPeriodBeginDate,
+
+        @RequestParam(name = "propPeriodEndDate", required = false) 
+        @Parameter(description = "Must be exact(?) Type java.time LocalDateTime, format 'yyyy-MM-ddTHH:mm:ss' ex '2018-04-01T04:00:00'")
+        LocalDateTime propPeriodEndDate,
+
         // project filters
         @RequestParam(name = "projectId", required = false) 
         @Parameter(description = "Must be exact")
@@ -134,18 +150,45 @@ public class FiltersController {
         List<String> resourceTypes,
 
         // auction filters
-        @RequestParam(name = "auctionId", required = false) 
+        @RequestParam(name = "commitPeriodId", required = false) 
         @Parameter(description = "Must be exact")
-        Integer auctionId,
+        Integer commitPeriodId,
 
-        // period filters
-        @RequestParam(name = "periodId", required = false) 
+        @RequestParam(name = "commitPeriodTypes", required = false) 
+        @Parameter(description = "Must be exact, can input multiple")
+        List<String> commitPeriodTypes,
+
+        @RequestParam(name = "commitPeriodDesc", required = false) 
+        @Parameter(description = "Searches for prefix: '200' can return file with commit period description '2001-02'")
+        String commitPeriodDesc,
+
+        @RequestParam(name = "commitPeriodBeginDate", required = false) 
+        @Parameter(description = "Must be exact(?) Type java.time LocalDateTime, format 'yyyy-MM-ddTHH:mm:ss' ex '2018-04-01T04:00:00'")
+        LocalDateTime commitPeriodBeginDate,
+
+        @RequestParam(name = "commitPeriodEndDate", required = false) 
+        @Parameter(description = "Must be exact(?) Type java.time LocalDateTime, format 'yyyy-MM-ddTHH:mm:ss' ex '2018-04-01T04:00:00'")
+        LocalDateTime commitPeriodEndDate,
+    
+        @RequestParam(name = "aucPeriodId", required = false) 
         @Parameter(description = "Must be exact")
-        Integer periodId,
+        Integer aucPeriodId,
 
-        @RequestParam(name = "periodDesc", required = false) 
-        @Parameter(description = "Searches for prefix: '2011' can return file with period description '2011-12'")
-        String periodDesc
+        @RequestParam(name = "aucPeriodTypes", required = false) 
+        @Parameter(description = "Must be exact, can input multiple")
+        List<String> aucPeriodTypes,
+
+        @RequestParam(name = "aucPeriodDesc", required = false) 
+        @Parameter(description = "Searches for prefix: '200' can return file with auction period description '2001-02'")
+        String aucPeriodDesc,
+
+        @RequestParam(name = "aucPeriodBeginDate", required = false) 
+        @Parameter(description = "Must be exact(?) Type java.time LocalDateTime, format 'yyyy-MM-ddTHH:mm:ss' ex '2018-04-01T04:00:00'")
+        LocalDateTime aucPeriodBeginDate,
+
+        @RequestParam(name = "aucPeriodEndDate", required = false) 
+        @Parameter(description = "Must be exact(?) Type java.time LocalDateTime, format 'yyyy-MM-ddTHH:mm:ss' ex '2018-04-01T04:00:00'")
+        LocalDateTime aucPeriodEndDate
 
         ) { //end parameters
 
@@ -182,12 +225,12 @@ public class FiltersController {
             pr, sortBy, sortAsc,
             fileId, fileName, fileDescription, createdSince, fileTypes,
             attachTypes,
-            proposalId, proposalLabel,
+            proposalId, proposalLabel, propPeriodId, propPeriodDesc, propPeriodBeginDate, propPeriodEndDate,
             projectId, projectName, projectTypes,
             customerId, customerName,
             resourceId, resourceName, resourceTypes,
-            auctionId,
-            periodId, periodDesc
+            commitPeriodId, commitPeriodTypes, commitPeriodDesc, commitPeriodBeginDate, commitPeriodEndDate,
+            aucPeriodId, aucPeriodTypes, aucPeriodDesc, aucPeriodBeginDate, aucPeriodEndDate
         );
 
         return filtersService.filterAttachments(filters);

--- a/sdm-iso-back/src/main/java/com/example/sdmisoback/dto/FiltersDTO.java
+++ b/sdm-iso-back/src/main/java/com/example/sdmisoback/dto/FiltersDTO.java
@@ -28,6 +28,7 @@ public class FiltersDTO {
     public Integer proposalId;
     public String proposalLabel;
     public Integer propPeriodId;
+    public List<String> propPeriodTypes;
     public String propPeriodDesc;
     public LocalDateTime propPeriodBeginDate;
     public LocalDateTime propPeriodEndDate;
@@ -47,12 +48,19 @@ public class FiltersDTO {
     public List<String> resourceTypes;
 
     // auction
+    public Integer auctionId;
+    public List<String> auctionTypes;
+    public LocalDateTime aucBeginDate;
+    public LocalDateTime aucEndDate;
+
+    // commitment period
     public Integer commitPeriodId;
     public List<String> commitPeriodTypes;
     public String commitPeriodDesc;
     public LocalDateTime commitPeriodBeginDate;
     public LocalDateTime commitPeriodEndDate;
 
+    // auction period
     public Integer aucPeriodId;
     public List<String> aucPeriodTypes;
     public String aucPeriodDesc;
@@ -60,52 +68,55 @@ public class FiltersDTO {
     public LocalDateTime aucPeriodEndDate;
 
     // cons
-	public FiltersDTO(PageRequest pr, String sortBy, boolean sortAsc, Integer fileId, String fileName,
-			String fileDescription, LocalDateTime createdSince, List<String> fileTypes, List<String> attachTypes,
-			Integer proposalId, String proposalLabel, Integer propPeriodId, String propPeriodDesc,
-			LocalDateTime propPeriodBeginDate, LocalDateTime propPeriodEndDate, Integer projectId, String projectName,
-			List<String> projectTypes, Integer customerId, String customerName, Integer resourceId, String resourceName,
-			List<String> resourceTypes, Integer commitPeriodId, List<String> commitPeriodTypes, String commitPeriodDesc,
-			LocalDateTime commitPeriodBeginDate, LocalDateTime commitPeriodEndDate, Integer aucPeriodId,
-			List<String> aucPeriodTypes, String aucPeriodDesc, LocalDateTime aucPeriodBeginDate,
-			LocalDateTime aucPeriodEndDate) {
-		this.pr = pr;
-		this.sortBy = sortBy;
-		this.sortAsc = sortAsc;
-		this.fileId = fileId;
-		this.fileName = fileName;
-		this.fileDescription = fileDescription;
-		this.createdSince = createdSince;
-		this.fileTypes = fileTypes;
-		this.attachTypes = attachTypes;
-		this.proposalId = proposalId;
-		this.proposalLabel = proposalLabel;
-		this.propPeriodId = propPeriodId;
-		this.propPeriodDesc = propPeriodDesc;
-		this.propPeriodBeginDate = propPeriodBeginDate;
-		this.propPeriodEndDate = propPeriodEndDate;
-		this.projectId = projectId;
-		this.projectName = projectName;
-		this.projectTypes = projectTypes;
-		this.customerId = customerId;
-		this.customerName = customerName;
-		this.resourceId = resourceId;
-		this.resourceName = resourceName;
-		this.resourceTypes = resourceTypes;
-		this.commitPeriodId = commitPeriodId;
-		this.commitPeriodTypes = commitPeriodTypes;
-		this.commitPeriodDesc = commitPeriodDesc;
-		this.commitPeriodBeginDate = commitPeriodBeginDate;
-		this.commitPeriodEndDate = commitPeriodEndDate;
-		this.aucPeriodId = aucPeriodId;
-		this.aucPeriodTypes = aucPeriodTypes;
-		this.aucPeriodDesc = aucPeriodDesc;
-		this.aucPeriodBeginDate = aucPeriodBeginDate;
-		this.aucPeriodEndDate = aucPeriodEndDate;
-	}
+    public FiltersDTO(PageRequest pr, String sortBy, boolean sortAsc, Integer fileId, String fileName,
+            String fileDescription, LocalDateTime createdSince, List<String> fileTypes, List<String> attachTypes,
+            Integer proposalId, String proposalLabel, Integer propPeriodId, List<String> propPeriodTypes,
+            String propPeriodDesc, LocalDateTime propPeriodBeginDate, LocalDateTime propPeriodEndDate,
+            Integer projectId, String projectName, List<String> projectTypes, Integer customerId, String customerName,
+            Integer resourceId, String resourceName, List<String> resourceTypes, Integer auctionId,
+            List<String> auctionTypes, LocalDateTime aucBeginDate, LocalDateTime aucEndDate, Integer commitPeriodId,
+            List<String> commitPeriodTypes, String commitPeriodDesc, LocalDateTime commitPeriodBeginDate,
+            LocalDateTime commitPeriodEndDate, Integer aucPeriodId, List<String> aucPeriodTypes, String aucPeriodDesc,
+            LocalDateTime aucPeriodBeginDate, LocalDateTime aucPeriodEndDate) {
+        this.pr = pr;
+        this.sortBy = sortBy;
+        this.sortAsc = sortAsc;
+        this.fileId = fileId;
+        this.fileName = fileName;
+        this.fileDescription = fileDescription;
+        this.createdSince = createdSince;
+        this.fileTypes = fileTypes;
+        this.attachTypes = attachTypes;
+        this.proposalId = proposalId;
+        this.proposalLabel = proposalLabel;
+        this.propPeriodId = propPeriodId;
+        this.propPeriodTypes = propPeriodTypes;
+        this.propPeriodDesc = propPeriodDesc;
+        this.propPeriodBeginDate = propPeriodBeginDate;
+        this.propPeriodEndDate = propPeriodEndDate;
+        this.projectId = projectId;
+        this.projectName = projectName;
+        this.projectTypes = projectTypes;
+        this.customerId = customerId;
+        this.customerName = customerName;
+        this.resourceId = resourceId;
+        this.resourceName = resourceName;
+        this.resourceTypes = resourceTypes;
+        this.auctionId = auctionId;
+        this.auctionTypes = auctionTypes;
+        this.aucBeginDate = aucBeginDate;
+        this.aucEndDate = aucEndDate;
+        this.commitPeriodId = commitPeriodId;
+        this.commitPeriodTypes = commitPeriodTypes;
+        this.commitPeriodDesc = commitPeriodDesc;
+        this.commitPeriodBeginDate = commitPeriodBeginDate;
+        this.commitPeriodEndDate = commitPeriodEndDate;
+        this.aucPeriodId = aucPeriodId;
+        this.aucPeriodTypes = aucPeriodTypes;
+        this.aucPeriodDesc = aucPeriodDesc;
+        this.aucPeriodBeginDate = aucPeriodBeginDate;
+        this.aucPeriodEndDate = aucPeriodEndDate;
+    }
 
-    
-    
-    
-    
+
 }

--- a/sdm-iso-back/src/main/java/com/example/sdmisoback/dto/FiltersDTO.java
+++ b/sdm-iso-back/src/main/java/com/example/sdmisoback/dto/FiltersDTO.java
@@ -1,7 +1,9 @@
 package com.example.sdmisoback.dto;
 
 import java.time.LocalDateTime;
+import java.time.LocalDate;
 import java.util.List;
+
 
 import org.springframework.data.domain.PageRequest;
 
@@ -30,8 +32,8 @@ public class FiltersDTO {
     public Integer propPeriodId;
     public List<String> propPeriodTypes;
     public String propPeriodDesc;
-    public LocalDateTime propPeriodBeginDate;
-    public LocalDateTime propPeriodEndDate;
+    public LocalDate propPeriodBeginDate;
+    public LocalDate propPeriodEndDate;
 
     // project
     public Integer projectId;
@@ -50,34 +52,34 @@ public class FiltersDTO {
     // auction
     public Integer auctionId;
     public List<String> auctionTypes;
-    public LocalDateTime aucBeginDate;
-    public LocalDateTime aucEndDate;
+    public LocalDate aucBeginDate;
+    public LocalDate aucEndDate;
 
     // commitment period
     public Integer commitPeriodId;
     public List<String> commitPeriodTypes;
     public String commitPeriodDesc;
-    public LocalDateTime commitPeriodBeginDate;
-    public LocalDateTime commitPeriodEndDate;
+    public LocalDate commitPeriodBeginDate;
+    public LocalDate commitPeriodEndDate;
 
     // auction period
     public Integer aucPeriodId;
     public List<String> aucPeriodTypes;
     public String aucPeriodDesc;
-    public LocalDateTime aucPeriodBeginDate;
-    public LocalDateTime aucPeriodEndDate;
+    public LocalDate aucPeriodBeginDate;
+    public LocalDate aucPeriodEndDate;
 
     // cons
     public FiltersDTO(PageRequest pr, String sortBy, boolean sortAsc, Integer fileId, String fileName,
             String fileDescription, LocalDateTime createdSince, List<String> fileTypes, List<String> attachTypes,
             Integer proposalId, String proposalLabel, Integer propPeriodId, List<String> propPeriodTypes,
-            String propPeriodDesc, LocalDateTime propPeriodBeginDate, LocalDateTime propPeriodEndDate,
+            String propPeriodDesc, LocalDate propPeriodBeginDate, LocalDate propPeriodEndDate,
             Integer projectId, String projectName, List<String> projectTypes, Integer customerId, String customerName,
             Integer resourceId, String resourceName, List<String> resourceTypes, Integer auctionId,
-            List<String> auctionTypes, LocalDateTime aucBeginDate, LocalDateTime aucEndDate, Integer commitPeriodId,
-            List<String> commitPeriodTypes, String commitPeriodDesc, LocalDateTime commitPeriodBeginDate,
-            LocalDateTime commitPeriodEndDate, Integer aucPeriodId, List<String> aucPeriodTypes, String aucPeriodDesc,
-            LocalDateTime aucPeriodBeginDate, LocalDateTime aucPeriodEndDate) {
+            List<String> auctionTypes, LocalDate aucBeginDate, LocalDate aucEndDate, Integer commitPeriodId,
+            List<String> commitPeriodTypes, String commitPeriodDesc, LocalDate commitPeriodBeginDate,
+            LocalDate commitPeriodEndDate, Integer aucPeriodId, List<String> aucPeriodTypes, String aucPeriodDesc,
+            LocalDate aucPeriodBeginDate, LocalDate aucPeriodEndDate) {
         this.pr = pr;
         this.sortBy = sortBy;
         this.sortAsc = sortAsc;

--- a/sdm-iso-back/src/main/java/com/example/sdmisoback/dto/FiltersDTO.java
+++ b/sdm-iso-back/src/main/java/com/example/sdmisoback/dto/FiltersDTO.java
@@ -27,6 +27,10 @@ public class FiltersDTO {
     // proposal
     public Integer proposalId;
     public String proposalLabel;
+    public Integer propPeriodId;
+    public String propPeriodDesc;
+    public LocalDateTime propPeriodBeginDate;
+    public LocalDateTime propPeriodEndDate;
 
     // project
     public Integer projectId;
@@ -43,41 +47,65 @@ public class FiltersDTO {
     public List<String> resourceTypes;
 
     // auction
-    public Integer auctionId;
+    public Integer commitPeriodId;
+    public List<String> commitPeriodTypes;
+    public String commitPeriodDesc;
+    public LocalDateTime commitPeriodBeginDate;
+    public LocalDateTime commitPeriodEndDate;
 
-    // period
-    public Integer periodId;
-    public String periodDesc;
+    public Integer aucPeriodId;
+    public List<String> aucPeriodTypes;
+    public String aucPeriodDesc;
+    public LocalDateTime aucPeriodBeginDate;
+    public LocalDateTime aucPeriodEndDate;
+
+    // cons
+	public FiltersDTO(PageRequest pr, String sortBy, boolean sortAsc, Integer fileId, String fileName,
+			String fileDescription, LocalDateTime createdSince, List<String> fileTypes, List<String> attachTypes,
+			Integer proposalId, String proposalLabel, Integer propPeriodId, String propPeriodDesc,
+			LocalDateTime propPeriodBeginDate, LocalDateTime propPeriodEndDate, Integer projectId, String projectName,
+			List<String> projectTypes, Integer customerId, String customerName, Integer resourceId, String resourceName,
+			List<String> resourceTypes, Integer commitPeriodId, List<String> commitPeriodTypes, String commitPeriodDesc,
+			LocalDateTime commitPeriodBeginDate, LocalDateTime commitPeriodEndDate, Integer aucPeriodId,
+			List<String> aucPeriodTypes, String aucPeriodDesc, LocalDateTime aucPeriodBeginDate,
+			LocalDateTime aucPeriodEndDate) {
+		this.pr = pr;
+		this.sortBy = sortBy;
+		this.sortAsc = sortAsc;
+		this.fileId = fileId;
+		this.fileName = fileName;
+		this.fileDescription = fileDescription;
+		this.createdSince = createdSince;
+		this.fileTypes = fileTypes;
+		this.attachTypes = attachTypes;
+		this.proposalId = proposalId;
+		this.proposalLabel = proposalLabel;
+		this.propPeriodId = propPeriodId;
+		this.propPeriodDesc = propPeriodDesc;
+		this.propPeriodBeginDate = propPeriodBeginDate;
+		this.propPeriodEndDate = propPeriodEndDate;
+		this.projectId = projectId;
+		this.projectName = projectName;
+		this.projectTypes = projectTypes;
+		this.customerId = customerId;
+		this.customerName = customerName;
+		this.resourceId = resourceId;
+		this.resourceName = resourceName;
+		this.resourceTypes = resourceTypes;
+		this.commitPeriodId = commitPeriodId;
+		this.commitPeriodTypes = commitPeriodTypes;
+		this.commitPeriodDesc = commitPeriodDesc;
+		this.commitPeriodBeginDate = commitPeriodBeginDate;
+		this.commitPeriodEndDate = commitPeriodEndDate;
+		this.aucPeriodId = aucPeriodId;
+		this.aucPeriodTypes = aucPeriodTypes;
+		this.aucPeriodDesc = aucPeriodDesc;
+		this.aucPeriodBeginDate = aucPeriodBeginDate;
+		this.aucPeriodEndDate = aucPeriodEndDate;
+	}
 
     
-    public FiltersDTO(PageRequest pr, String sortBy, boolean sortAsc, Integer fileId, String fileName,
-            String fileDescription, LocalDateTime createdSince, List<String> fileTypes, List<String> attachTypes,
-            Integer proposalId, String proposalLabel, Integer projectId, String projectName, List<String> projectTypes,
-            Integer customerId, String customerName, Integer resourceId, String resourceName,
-            List<String> resourceTypes, Integer auctionId, Integer periodId, String periodDesc) {
-        this.pr = pr;
-        this.sortBy = sortBy;
-        this.sortAsc = sortAsc;
-        this.fileId = fileId;
-        this.fileName = fileName;
-        this.fileDescription = fileDescription;
-        this.createdSince = createdSince;
-        this.fileTypes = fileTypes;
-        this.attachTypes = attachTypes;
-        this.proposalId = proposalId;
-        this.proposalLabel = proposalLabel;
-        this.projectId = projectId;
-        this.projectName = projectName;
-        this.projectTypes = projectTypes;
-        this.customerId = customerId;
-        this.customerName = customerName;
-        this.resourceId = resourceId;
-        this.resourceName = resourceName;
-        this.resourceTypes = resourceTypes;
-        this.auctionId = auctionId;
-        this.periodId = periodId;
-        this.periodDesc = periodDesc;
-    }
+    
     
     
 }

--- a/sdm-iso-back/src/main/java/com/example/sdmisoback/repository/CustomFiltersRepoImpl.java
+++ b/sdm-iso-back/src/main/java/com/example/sdmisoback/repository/CustomFiltersRepoImpl.java
@@ -79,6 +79,9 @@ public class CustomFiltersRepoImpl implements CustomFiltersRepo{
         if(f.propPeriodId != null)
             cb.where(proposal + ".periodInfo.periodId").eq(f.propPeriodId);
 
+        if(f.propPeriodTypes != null)
+            cb.where(proposal + ".periodInfo.periodType").in(f.propPeriodTypes);
+
         if(f.propPeriodDesc != null)
             cb.where(proposal + ".periodInfo.description").like(false).value(f.propPeriodDesc + "%").noEscape();
 
@@ -115,6 +118,19 @@ public class CustomFiltersRepoImpl implements CustomFiltersRepo{
         if(f.resourceTypes != null)
             cb.where(proposal + ".resInfo.resourceType.resourceType").in(f.resourceTypes);
 
+        // auction filters
+        if(f.auctionId != null)
+            cb.where(proposal + ".auctionInfo.auctionId").eq(f.auctionId);
+
+        if(f.auctionTypes != null)
+            cb.where(proposal + ".auctionInfo.auctionType").in(f.auctionTypes);
+
+        if(f.aucBeginDate != null)
+            cb.where(proposal + ".auctionInfo.auctionBeginDate").ge(f.aucBeginDate);
+
+        if(f.aucEndDate != null)
+            cb.where(proposal + ".auctionInfo.auctionEndDate").le(f.aucEndDate);
+
         // commitment period filters
         if(f.commitPeriodId != null)
             cb.where(proposal + ".auctionInfo.commitmentPeriodInfo.periodId").eq(f.commitPeriodId);
@@ -126,12 +142,11 @@ public class CustomFiltersRepoImpl implements CustomFiltersRepo{
             cb.where(proposal + ".auctionInfo.commitmentPeriodInfo.description").like(false).value(f.commitPeriodDesc + "%").noEscape();
 
         if(f.commitPeriodBeginDate != null)
-            cb.where(proposal + ".auctionInfo.commitmentPeriodInfo.beginDate").eq(f.commitPeriodBeginDate);
+            cb.where(proposal + ".auctionInfo.commitmentPeriodInfo.beginDate").ge(f.commitPeriodBeginDate);
 
         if(f.commitPeriodEndDate != null)
-            cb.where(proposal + ".auctionInfo.commitmentPeriodInfo.endDate").eq(f.commitPeriodEndDate);
+            cb.where(proposal + ".auctionInfo.commitmentPeriodInfo.endDate").le(f.commitPeriodEndDate);
 
-        
         // auction period filters
         if(f.aucPeriodId != null)
             cb.where(proposal + ".auctionInfo.auctionPeriodInfo.periodId").eq(f.aucPeriodId);
@@ -143,10 +158,10 @@ public class CustomFiltersRepoImpl implements CustomFiltersRepo{
             cb.where(proposal + ".auctionInfo.auctionPeriodInfo.description").like(false).value(f.aucPeriodDesc + "%").noEscape();
 
         if(f.aucPeriodBeginDate != null)
-            cb.where(proposal + ".auctionInfo.auctionPeriodInfo.beginDate").eq(f.aucPeriodBeginDate);
+            cb.where(proposal + ".auctionInfo.auctionPeriodInfo.beginDate").ge(f.aucPeriodBeginDate);
 
         if(f.aucPeriodEndDate != null)
-            cb.where(proposal + ".auctionInfo.auctionPeriodInfo.endDate").eq(f.aucPeriodEndDate);
+            cb.where(proposal + ".auctionInfo.auctionPeriodInfo.endDate").le(f.aucPeriodEndDate);
 
         
         // add pagination here

--- a/sdm-iso-back/src/main/java/com/example/sdmisoback/repository/CustomFiltersRepoImpl.java
+++ b/sdm-iso-back/src/main/java/com/example/sdmisoback/repository/CustomFiltersRepoImpl.java
@@ -86,10 +86,10 @@ public class CustomFiltersRepoImpl implements CustomFiltersRepo{
             cb.where(proposal + ".periodInfo.description").like(false).value(f.propPeriodDesc + "%").noEscape();
 
         if(f.propPeriodBeginDate != null)
-            cb.where(proposal + ".periodInfo.beginDate").eq(f.propPeriodBeginDate);
+            cb.where("CAST_DATE(" + proposal + ".periodInfo.beginDate)").ge(f.propPeriodBeginDate);
 
         if(f.propPeriodEndDate != null)
-            cb.where(proposal + ".periodInfo.endDate").eq(f.propPeriodEndDate);
+            cb.where("CAST_DATE(" + proposal + ".periodInfo.endDate)").le(f.propPeriodEndDate);
 
         // project filters
         if(f.projectId != null)
@@ -126,10 +126,10 @@ public class CustomFiltersRepoImpl implements CustomFiltersRepo{
             cb.where(proposal + ".auctionInfo.auctionType").in(f.auctionTypes);
 
         if(f.aucBeginDate != null)
-            cb.where(proposal + ".auctionInfo.auctionBeginDate").ge(f.aucBeginDate);
+            cb.where("CAST_DATE(" + proposal + ".auctionInfo.auctionBeginDate)").ge(f.aucBeginDate);
 
         if(f.aucEndDate != null)
-            cb.where(proposal + ".auctionInfo.auctionEndDate").le(f.aucEndDate);
+            cb.where("CAST_DATE(" + proposal + ".auctionInfo.auctionEndDate)").le(f.aucEndDate);
 
         // commitment period filters
         if(f.commitPeriodId != null)
@@ -142,10 +142,10 @@ public class CustomFiltersRepoImpl implements CustomFiltersRepo{
             cb.where(proposal + ".auctionInfo.commitmentPeriodInfo.description").like(false).value(f.commitPeriodDesc + "%").noEscape();
 
         if(f.commitPeriodBeginDate != null)
-            cb.where(proposal + ".auctionInfo.commitmentPeriodInfo.beginDate").ge(f.commitPeriodBeginDate);
+            cb.where("CAST_DATE(" + proposal + ".auctionInfo.commitmentPeriodInfo.beginDate)").ge(f.commitPeriodBeginDate);
 
         if(f.commitPeriodEndDate != null)
-            cb.where(proposal + ".auctionInfo.commitmentPeriodInfo.endDate").le(f.commitPeriodEndDate);
+            cb.where("CAST_DATE(" + proposal + ".auctionInfo.commitmentPeriodInfo.endDate)").le(f.commitPeriodEndDate);
 
         // auction period filters
         if(f.aucPeriodId != null)
@@ -158,10 +158,10 @@ public class CustomFiltersRepoImpl implements CustomFiltersRepo{
             cb.where(proposal + ".auctionInfo.auctionPeriodInfo.description").like(false).value(f.aucPeriodDesc + "%").noEscape();
 
         if(f.aucPeriodBeginDate != null)
-            cb.where(proposal + ".auctionInfo.auctionPeriodInfo.beginDate").ge(f.aucPeriodBeginDate);
+            cb.where("CAST_DATE(" + proposal + ".auctionInfo.auctionPeriodInfo.beginDate)").ge(f.aucPeriodBeginDate);
 
         if(f.aucPeriodEndDate != null)
-            cb.where(proposal + ".auctionInfo.auctionPeriodInfo.endDate").le(f.aucPeriodEndDate);
+            cb.where("CAST_DATE(" + proposal + ".auctionInfo.auctionPeriodInfo.endDate)").le(f.aucPeriodEndDate);
 
         
         // add pagination here

--- a/sdm-iso-back/src/main/java/com/example/sdmisoback/repository/CustomFiltersRepoImpl.java
+++ b/sdm-iso-back/src/main/java/com/example/sdmisoback/repository/CustomFiltersRepoImpl.java
@@ -1,7 +1,5 @@
 package com.example.sdmisoback.repository;
 
-import jakarta.persistence.EntityManager;
-
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 
@@ -13,7 +11,9 @@ import com.blazebit.persistence.view.EntityViewManager;
 import com.blazebit.persistence.view.EntityViewSetting;
 import com.example.sdmisoback.dto.AttachmentFileView;
 import com.example.sdmisoback.dto.FiltersDTO;
-import com.example.sdmisoback.model.*;
+import com.example.sdmisoback.model.AttachmentFile;
+
+import jakarta.persistence.EntityManager;
 
 
 public class CustomFiltersRepoImpl implements CustomFiltersRepo{
@@ -76,6 +76,18 @@ public class CustomFiltersRepoImpl implements CustomFiltersRepo{
         if(f.proposalLabel != null)
             cb.where(proposal + ".proposalLabel").like(false).value('%'+f.proposalLabel + '%').noEscape();
 
+        if(f.propPeriodId != null)
+            cb.where(proposal + ".periodInfo.periodId").eq(f.propPeriodId);
+
+        if(f.propPeriodDesc != null)
+            cb.where(proposal + ".periodInfo.description").like(false).value(f.propPeriodDesc + "%").noEscape();
+
+        if(f.propPeriodBeginDate != null)
+            cb.where(proposal + ".periodInfo.beginDate").eq(f.propPeriodBeginDate);
+
+        if(f.propPeriodEndDate != null)
+            cb.where(proposal + ".periodInfo.endDate").eq(f.propPeriodEndDate);
+
         // project filters
         if(f.projectId != null)
             cb.where(proposal + ".projInfo.projectId").eq(f.projectId);
@@ -103,16 +115,39 @@ public class CustomFiltersRepoImpl implements CustomFiltersRepo{
         if(f.resourceTypes != null)
             cb.where(proposal + ".resInfo.resourceType.resourceType").in(f.resourceTypes);
 
-        // auction filters
-        if(f.auctionId != null)
-            cb.where(proposal + ".auctionInfo.auctionId").eq(f.auctionId);
+        // commitment period filters
+        if(f.commitPeriodId != null)
+            cb.where(proposal + ".auctionInfo.commitmentPeriodInfo.periodId").eq(f.commitPeriodId);
 
-        // period filters
-        if(f.periodId != null)
-            cb.where(proposal + ".periodInfo.periodId").eq(f.periodId);
+        if(f.commitPeriodTypes != null)
+            cb.where(proposal + ".auctionInfo.commitmentPeriodInfo.periodType").in(f.commitPeriodTypes);
+
+        if(f.commitPeriodDesc != null)
+            cb.where(proposal + ".auctionInfo.commitmentPeriodInfo.description").like(false).value(f.commitPeriodDesc + "%").noEscape();
+
+        if(f.commitPeriodBeginDate != null)
+            cb.where(proposal + ".auctionInfo.commitmentPeriodInfo.beginDate").eq(f.commitPeriodBeginDate);
+
+        if(f.commitPeriodEndDate != null)
+            cb.where(proposal + ".auctionInfo.commitmentPeriodInfo.endDate").eq(f.commitPeriodEndDate);
+
         
-        if(f.periodDesc != null)
-            cb.where(proposal + ".periodInfo.description").like(false).value(f.periodDesc+'%').noEscape();
+        // auction period filters
+        if(f.aucPeriodId != null)
+            cb.where(proposal + ".auctionInfo.auctionPeriodInfo.periodId").eq(f.aucPeriodId);
+
+        if(f.aucPeriodTypes != null)
+            cb.where(proposal + ".auctionInfo.auctionPeriodInfo.periodType").in(f.aucPeriodTypes);
+
+        if(f.aucPeriodDesc != null)
+            cb.where(proposal + ".auctionInfo.auctionPeriodInfo.description").like(false).value(f.aucPeriodDesc + "%").noEscape();
+
+        if(f.aucPeriodBeginDate != null)
+            cb.where(proposal + ".auctionInfo.auctionPeriodInfo.beginDate").eq(f.aucPeriodBeginDate);
+
+        if(f.aucPeriodEndDate != null)
+            cb.where(proposal + ".auctionInfo.auctionPeriodInfo.endDate").eq(f.aucPeriodEndDate);
+
         
         // add pagination here
         // first is creating the "setting" to apply pagination


### PR DESCRIPTION
added:

- proposal period: id/types/desc/begin-end date
- auction commitment period: id/types/desc/begin-end date
- auction auction period: id/types/desc/begin-end date

id is exact match
types are exact match + multiple inputs
desc is like% (read and autocomplete from front)
begin/end date is leq/geq exact value (subject to change -> might want lessen constraints and match by year instead)

requesting feedback specifically on begin/end date

- [x] need to test all the new endpoints