### PR TITLE
fix front filter values sending to backend

### DIFF
--- a/sdm-iso-front/src/components/FileList/filters/auctionTypes.jsx
+++ b/sdm-iso-front/src/components/FileList/filters/auctionTypes.jsx
@@ -1,34 +1,32 @@
-import { defaultAll } from "./common";
-
 export const auctionTypesFilter = [
-    {
-      id: "fca",
-      label: "FCA",
-      default: false,
-    },
-    {
-      id: "rca2",
-      label: "RCA2",
-      default: false,
-    },
-    {
-      id: "ara",
-      label: "ARA1/2/3",
-      default: false,
-    },
-    {
-      id: "mra",
-      label: "MRA",
-      default: false,
-    },
-    {
-      id: "annual",
-      label: "Annual",
-      default: false,
-    },
-    {
-      id: "monthly",
-      label: "Monthly",
-      default: false,
-    }
-  ];
+  {
+    id: "FCA",
+    label: "FCA",
+    default: false,
+  },
+  {
+    id: "RCA2", // not sure if this is right
+    label: "RCA2",
+    default: false,
+  },
+  {
+    id: "ARA", // not sure if this is right
+    label: "ARA1/2/3",
+    default: false,
+  },
+  {
+    id: "MRA", // not sure if this is right
+    label: "MRA",
+    default: false,
+  },
+  {
+    id: "ANNUAL", // not sure if this is right
+    label: "Annual",
+    default: false,
+  },
+  {
+    id: "MONTHLY", // not sure if this is right
+    label: "Monthly",
+    default: false,
+  }
+];

--- a/sdm-iso-front/src/components/FileList/filters/common.jsx
+++ b/sdm-iso-front/src/components/FileList/filters/common.jsx
@@ -1,1 +1,2 @@
 export const defaultAll = "all";
+// should be scheduled to download because we don't  use this variable anymore

--- a/sdm-iso-front/src/components/FileList/filters/fileTypes.jsx
+++ b/sdm-iso-front/src/components/FileList/filters/fileTypes.jsx
@@ -1,49 +1,47 @@
-import { defaultAll } from "./common";
-
 export const fileTypesFilter = [
-    {
-      id: "bmp",
-      label: "BMP",
-      default: false,
-    },
-    {
-      id: "doc",
-      label: "DOC/DOCX",
-      default: false,
-    },
-    {
-      id: "htm",
-      label: "HTM/HTML",
-      default: false,
-    },
-    {
-      id: "jpg",
-      label: "JPG",
-      default: false,
-    },
-    {
-      id: "msg",
-      label: "MSG",
-      default: false,
-    },
-    {
-      id: "pdf",
-      label: "PDF",
-      default: false,
-    },
-    {
-      id: "txt",
-      label: "TXT",
-      default: false,
-    },
-    {
-      id: "xls",
-      label: "XLSM/XLSX",
-      default: false,
-    },
-    {
-      id: "zip",
-      label: "ZIP",
-      default: false,
-    },
-  ];
+  {
+    id: "bmp",
+    label: "BMP",
+    default: false,
+  },
+  {
+    id: ["doc", "docx"],
+    label: "DOC/DOCX",
+    default: false,
+  },
+  {
+    id: ["htm", "html"],
+    label: "HTM/HTML",
+    default: false,
+  },
+  {
+    id: ["jpg", "jpeg"],
+    label: "JPG",
+    default: false,
+  },
+  {
+    id: "msg",
+    label: "MSG",
+    default: false,
+  },
+  {
+    id: "pdf",
+    label: "PDF",
+    default: false,
+  },
+  {
+    id: "txt",
+    label: "TXT",
+    default: false,
+  },
+  {
+    id: ["xls", "xlsm", "xlsx"],
+    label: "XLSM/XLSX",
+    default: false,
+  },
+  {
+    id: ["zip", "zipx"],
+    label: "ZIP",
+    default: false,
+  },
+];

--- a/sdm-iso-front/src/components/FileList/filters/projectTypes.jsx
+++ b/sdm-iso-front/src/components/FileList/filters/projectTypes.jsx
@@ -2,52 +2,52 @@ import { defaultAll } from "./common";
 
 export const projectTypesFilter = [
     {
-        id: 'new_gen',
+        id: 'NEW_GEN', // not sure if this is correct
         label: "New Generation",
         default: false,
     },
     {
-        id: 'new_import',
+        id: 'NEW_IMPORT',
         label: "New Import",
         default: false,
     },
     {
-        id: 'increase_above',
+        id: 'INCREASE_ABOVE', // not sure if this is correct
         label: "Increase above Threshold",
         default: false,
     },
     {
-        id: 'repower',
+        id: 'REPOWER', // not sure if this is correct
         label: "Repowering",
         default: false,
     },
     {
-        id: 'env_comp',
+        id: 'ENV_COMP', // not sure if this is correct
         label: "Environmental Upgrade",
         default: false,
     },
     {
-        id: 'incremental',
+        id: 'INCREMENTAL', // not sure if this is correct
         label: "Incremental Capacity",
         default: false,
     },
     {
-        id: 'derating',
+        id: 'DERATING', // not sure if this is correct
         label: "Reestablishment",
         default: false,
     },
     {
-        id: 'sig_inc',
+        id: 'SIG_INC', // not sure if this is correct
         label: "Significant Increase",
         default: false,
     },
     {
-        id: 'new_dr',
+        id: 'NEW_DR',
         label: "New Demand Resource",
         default: false,
     },
     {
-        id: 'existing_dr',
+        id: 'EXISTING_DR', // not sure if this is correct
         label: "Increase of Demand Resource",
         default: false,
     },

--- a/sdm-iso-front/src/components/FileList/filters/resourceTypes.jsx
+++ b/sdm-iso-front/src/components/FileList/filters/resourceTypes.jsx
@@ -2,17 +2,17 @@ import { defaultAll } from "./common";
 
 export const resourceTypesFilter = [
     {
-        id: "gen",
+        id: "GEN",
         label: "Generator",
         default: false,
     },
     {
-        id: "dr",
+        id: "DR",
         label: "Demand Resource",
         default: false,
     },
     {
-        id: "import",
+        id: "IMPORT",
         label: "Import",
         default: false,
     },


### PR DESCRIPTION
`defaultAll` should be scheduled to download because we won't use that anymore.

Some values I am not sure if it is correct but the pattern so far is just caps lock and that should work.